### PR TITLE
feat: add a new reason code for supporting suspended documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,5 +173,6 @@ Remove an entry from the revocation table:
 | removeFromCRL        | 8    |
 | privilegeWithdrawn   | 9    |
 | aACompromise         | 10   |
+| suspended            | 1001 |
 
 > **_NOTE:_** The code number 7 is not used

--- a/src/functions/insert/handler.ts
+++ b/src/functions/insert/handler.ts
@@ -7,7 +7,7 @@ import { putItem } from "@services/dynamoDb";
 
 import schema from "./schema";
 
-const REASON_CODES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const REASON_CODES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1001];
 
 const insert: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) => {
   const { documentHash, reasonCode } = event.body;


### PR DESCRIPTION
# Context 

To address the need for clear communication of document status, introduce a custom reason code specifically for `suspended`. This differentiation will enable verifiers to distinguish between `revoked` and `suspended` statuses, ensuring the delivery of appropriate messages tailored to each status on document verifiers.

For example, in contexts like a doctor's license, the term `revoked` carries severe negative implications, potentially damaging the subject's reputation. In contrast, the term `suspended` conveys a temporary hold, aligning better with situations where the intent is not to permanently invalidate the license but to temporarily pause its validity.

# What does this PR do?

- Add reason code `1001` to represent `suspended`
  - `1001` is used as none of the existing reason codes that are based on [CRL](https://en.wikipedia.org/wiki/Certificate_revocation_list) fits the `suspended` use case
